### PR TITLE
change rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'factory_girl'
 gem 'ffaker'
 gem 'haml'
 gem 'rspec'
-gem 'rubocop'
+gem 'rubocop', '~> 0.49.1', require: false
 gem 'shoulda-matchers'
 gem 'simple_form'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.3)
   rspec
-  rubocop
+  rubocop (~> 0.49.1)
   sass-rails (~> 5.0)
   selenium-webdriver
   shoulda-matchers


### PR DESCRIPTION

I've changed Gemfile by adding proper, stable version of rubocop. It is working now.

RuboCop's development is moving at a very rapid pace and there are often backward-incompatible changes between minor releases (since we haven't reached version 1.0 yet). To prevent an unwanted RuboCop update you might want to use a conservative version locking in your Gemfile:

**gem 'rubocop', '~> 0.49.1', require: false**
